### PR TITLE
js-base64 を git submodule から除外しました

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "js-base64"]
-	path = js-base64
-	url = https://github.com/dankogai/js-base64


### PR DESCRIPTION
js-base64 も 8621be9 で npm の管理下に置かれたので、git submodule から除外しました

`--recursive` 付けて clone しても js-base64 は clone されなかったので、もしかしたら @hoshimi の手元でやったほうがよいかもしれないです。

[git submoduleを今風な感じで削除する - Qiita](http://qiita.com/u1aryz/items/8d1923da79158439eeaa)