### PR TITLE
GITHUB_API_TOKEN を環境変数から読み込むようにした

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "react"
+  ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,8 @@
 {
   "presets": [
     "react"
+  ],
+  "plugins": [
+    "transform-inline-environment-variables"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ js-base64
 html2canvas
 gana.js
 build/content.js
-src/secret_consts.js

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
         <!-- Latest compiled and minified Bootstrap CSS -->
         <link rel="stylesheet" href="css/bootstrap.min.css">
 
+        <meta charset="UTF-8">
+
         <!-- Font Awesome -->
         <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
         <meta name="viewport" content="width=device-width,maximum-scale=1" />

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "author": "hoshimi",
   "license": "MIT",
   "devDependencies": {
+    "babel-plugin-transform-inline-environment-variables": "0.0.2",
     "babel-preset-react": "6.23.0",
     "babelify": "7.3.0",
     "browserify": "13.1.0",

--- a/package.json
+++ b/package.json
@@ -3,21 +3,20 @@
   "version": "0.0.1",
   "description": "moto-calculator",
   "dependencies": {
+    "jquery": "~3.1.0",
+    "js-base64": "~2.1.9",
     "react": "~15.3.0",
     "react-bootstrap": "~0.30.2",
     "react-dom": "~15.3.0",
     "react-google-charts": "~1.0.2",
-    "reactify": "~1.1.1",
-    "react-language": "~0.1.3",
-    "jquery": "~3.1.0",
-    "js-base64": "~2.1.9"
+    "react-language": "~0.1.3"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "$(npm bin)/browserify -t reactify src/content.js -o build/content.js",
-    "production-build": "NODE_ENV=production $(npm bin)/browserify -t reactify src/content.js -o build/content.js",
-    "watch-dev": "$(npm bin)/watchify -v -t reactify src/content.js -o build/content.js",
-    "production-watch-dev": "NODE_ENV=production $(npm bin)/watchify -v -t reactify src/content.js -o build/content.js"
+    "build": "$(npm bin)/browserify -t babelify src/content.js -o build/content.js",
+    "production-build": "NODE_ENV=production $(npm bin)/browserify -t babelify src/content.js -o build/content.js",
+    "watch-dev": "$(npm bin)/watchify -v -t babelify src/content.js -o build/content.js",
+    "production-watch-dev": "NODE_ENV=production $(npm bin)/watchify -v -t babelify src/content.js -o build/content.js"
   },
   "repository": {
     "type": "git",
@@ -26,6 +25,8 @@
   "author": "hoshimi",
   "license": "MIT",
   "devDependencies": {
+    "babel-preset-react": "6.23.0",
+    "babelify": "7.3.0",
     "browserify": "13.1.0",
     "watchify": "3.7.0"
   }

--- a/src/secret_consts.js
+++ b/src/secret_consts.js
@@ -1,0 +1,1 @@
+module.exports.githubAPItoken = process.env.GITHUB_API_TOKEN

--- a/src/secret_consts.js.sample
+++ b/src/secret_consts.js.sample
@@ -1,1 +1,0 @@
-module.exports.githubAPItoken = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"


### PR DESCRIPTION
clone してから README に書いてある build までの手順を試すと、 *src/secret_consts.js* が無いと言われてギョっとなるので、何もしなくてもビルドが通るようにした。

これを Merge すると、 `GITHUB_API_TOKEN=XXXXX npm run build` とすることで `githubAPItoken` にトークンが入ります。

`transform-inline-environment-variables` はソースコードにかかれている `process.env.XXX` をトランスパイル時に環境変数に設定されている文字列に置き換えてくれるものです。

この作業にあたって、 browserify の transform module を reactify から babelify に変更しました。
babelify を使うようになったので、 webpack 移行も多少はしやすくなったと思います（本当に多少）
